### PR TITLE
Upgrade bootstrap-sass dependency to 3.3.5. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/dist/css/crubrand.min.css.map
 .sass-cache
 watch
 dev.html
+.idea

--- a/bootstrap-variations/_pagination.scss
+++ b/bootstrap-variations/_pagination.scss
@@ -87,10 +87,10 @@
 
 // Large
 .pagination-lg {
-    @include pagination-size($padding-base-vertical, $padding-base-horizontal, $font-size-base, $border-radius-base);
+    @include pagination-size($padding-base-vertical, $padding-base-horizontal, $font-size-base, $line-height-base, $border-radius-base);
 }
 
 // Small
 .pagination-sm {
-    @include pagination-size($padding-base-vertical, $padding-base-horizontal, $font-size-base, $border-radius-base);
+    @include pagination-size($padding-base-vertical, $padding-base-horizontal, $font-size-base, $line-height-base, $border-radius-base);
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "crubrand",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "homepage": "https://github.com/CruGlobal/crubrand",
   "authors": [
     "Elikem Adadevoh <elikem@gmail.com>",
@@ -23,6 +23,6 @@
     "tests"
   ],
   "dependencies": {
-    "bootstrap-sass-official": "3.3.1"
+    "bootstrap-sass-official": "3.3.5"
   }
 }


### PR DESCRIPTION
Fix call to pagination-size mixin that didn't have line-height parameter.

Got an error about the above during compile and fixed it.
Haven't tested any other parts of the framework after upgrade but might do more testing if I continue to use it.
