### PR TITLE
Remove Second $brand-info

### DIFF
--- a/variables/_colors.scss
+++ b/variables/_colors.scss
@@ -12,8 +12,6 @@ $colorCru-orange:     #dd7d1b;
 $colorCru-blueDeep:   #007398;
 $colorCru-blueBright: #3eb1c8;
 
-$brand-info: lighten($colorCru-blueBright, 40%);
-
 
 /**
  * Type


### PR DESCRIPTION
There is a second $brand-info variable in _colors.scss. This variable creates too light of a label color, it looks better with the default Bootstrap color, which is what is being used for .btn-info.